### PR TITLE
adding wizard steps programmatically

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 
 buildscript {
-    ext.cubaVersion = '6.8.8'
+    ext.cubaVersion = '6.8.9'
     repositories {
         
         maven {

--- a/modules/gui/src/de/diedavids/cuba/wizard/gui/components/Wizard.java
+++ b/modules/gui/src/de/diedavids/cuba/wizard/gui/components/Wizard.java
@@ -9,6 +9,7 @@ public interface Wizard extends Component.OrderedContainer,
                 Component.HasIcon, Component.HasCaption {
     String NAME = "wizard";
 
+    WizardStep addStep(int index, String name, WizardStepAware wizardStep);
     void addStep(int index, WizardStep wizardStep);
 
     WizardStep getStep(String stepId);

--- a/modules/gui/src/de/diedavids/cuba/wizard/gui/components/Wizard.java
+++ b/modules/gui/src/de/diedavids/cuba/wizard/gui/components/Wizard.java
@@ -17,7 +17,41 @@ public interface Wizard extends Component.OrderedContainer,
     void removeWizardStepChangeListener(WizardStepChangeListener listener);
 
     class WizardStepChangeEvent extends EventObject {
-        public WizardStepChangeEvent(Wizard source) {
+
+        WizardStep prevStep;
+        WizardStep step;
+
+        public WizardStepChangeEvent(Wizard source, WizardStep prevStep, WizardStep step) {
+            super(source);
+            this.prevStep = prevStep;
+            this.step = step;
+        }
+
+        @Override
+        public Wizard getSource() {
+            return (Wizard) super.getSource();
+        }
+
+        public WizardStep getPrevStep() {
+            return prevStep;
+        }
+
+        public WizardStep getStep() {
+            return step;
+        }
+    }
+
+    @FunctionalInterface
+    interface WizardStepChangeListener {
+        void stepChanged(Wizard.WizardStepChangeEvent event);
+    }
+
+
+    void addWizardCancelClickListener(WizardCancelClickListener listener);
+    void removeWizardCancelClickListener(WizardCancelClickListener listener);
+
+    class WizardCancelClickEvent extends EventObject {
+        public WizardCancelClickEvent(Wizard source) {
             super(source);
         }
 
@@ -28,9 +62,11 @@ public interface Wizard extends Component.OrderedContainer,
     }
 
     @FunctionalInterface
-    interface WizardStepChangeListener {
-        void stepChanged(Wizard.WizardStepChangeEvent event);
+    interface WizardCancelClickListener {
+        void cancelClicked(Wizard.WizardCancelClickEvent event);
     }
+
+
 
 
     void addWizardFinishClickListener(WizardFinishClickListener listener);

--- a/modules/gui/src/de/diedavids/cuba/wizard/gui/components/WizardStep.java
+++ b/modules/gui/src/de/diedavids/cuba/wizard/gui/components/WizardStep.java
@@ -1,5 +1,6 @@
 package de.diedavids.cuba.wizard.gui.components;
 
+import com.haulmont.cuba.gui.components.TabSheet;
 import com.haulmont.cuba.gui.components.VBoxLayout;
 
 public interface WizardStep extends VBoxLayout {
@@ -8,4 +9,6 @@ public interface WizardStep extends VBoxLayout {
     void onActivate();
 
     boolean preClose();
+
+    void setWrapperComponent(TabSheet.Tab tabComponent);
 }

--- a/modules/web/src/de/diedavids/cuba/wizard/web-screens.xml
+++ b/modules/web/src/de/diedavids/cuba/wizard/web-screens.xml
@@ -9,4 +9,6 @@
             template="de/diedavids/cuba/wizard/web/screens/examples/example1/steps/example-1-step-2.xml"/>
     <screen id="example-1-step-3-frame"
             template="de/diedavids/cuba/wizard/web/screens/examples/example1/steps/example-1-step-3.xml"/>
+    <screen id="example-1-step-4-frame"
+            template="de/diedavids/cuba/wizard/web/screens/examples/example1/steps/example-1-step-4.xml"/>
 </screen-config>

--- a/modules/web/src/de/diedavids/cuba/wizard/web/gui/components/WebWizard.java
+++ b/modules/web/src/de/diedavids/cuba/wizard/web/gui/components/WebWizard.java
@@ -372,6 +372,8 @@ public class WebWizard extends WebCssLayout implements Wizard {
         steps.put(tab, wizardStep);
         stepsById.put(wizardStep.getId(), wizardStep);
 
+        wizardStep.setWrapperComponent(tab);
+
         wizardStep.setMargin(true, false, true, false);
 
         tabList.add(index, tab);
@@ -385,6 +387,7 @@ public class WebWizard extends WebCssLayout implements Wizard {
             disableTab(tab);
         }
     }
+
 
     private boolean tabListHasOnlyThisTab(TabSheet.Tab tab) {
         return tabList.size() == 1 && tabList.get(0).equals(tab);

--- a/modules/web/src/de/diedavids/cuba/wizard/web/gui/components/WebWizard.java
+++ b/modules/web/src/de/diedavids/cuba/wizard/web/gui/components/WebWizard.java
@@ -10,6 +10,7 @@ import com.haulmont.cuba.web.toolkit.ui.CubaCssActionsLayout;
 import de.diedavids.cuba.wizard.gui.components.Wizard;
 import com.haulmont.cuba.web.gui.components.WebCssLayout;
 import de.diedavids.cuba.wizard.gui.components.WizardStep;
+import de.diedavids.cuba.wizard.gui.components.WizardStepAware;
 
 import java.util.*;
 
@@ -69,6 +70,7 @@ public class WebWizard extends WebCssLayout implements Wizard {
     public void removeAll() {
         throw new UnsupportedOperationException();
     }
+
 
     @Override
     public WizardStep getStep(String stepId) {
@@ -356,9 +358,16 @@ public class WebWizard extends WebCssLayout implements Wizard {
         return tabSheetLayout;
     }
 
+
+    @Override
+    public WizardStep addStep(int index, String name, WizardStepAware wizardStepAware) {
+        WebWizardStep wizardStep = new WebWizardStep(name, wizardStepAware);
+        addStep(index, wizardStep);
+        return wizardStep;
+    }
+
     @Override
     public void addStep(int index, WizardStep wizardStep) {
-
         TabSheet.Tab tab = tabSheetLayout.addTab(wizardStep.getId(), wizardStep);
         steps.put(tab, wizardStep);
         stepsById.put(wizardStep.getId(), wizardStep);

--- a/modules/web/src/de/diedavids/cuba/wizard/web/gui/components/WebWizardStep.java
+++ b/modules/web/src/de/diedavids/cuba/wizard/web/gui/components/WebWizardStep.java
@@ -1,27 +1,56 @@
 package de.diedavids.cuba.wizard.web.gui.components;
 
+import com.haulmont.cuba.gui.components.Component;
+import com.haulmont.cuba.gui.components.TabSheet;
 import com.haulmont.cuba.web.gui.components.WebVBoxLayout;
 import de.diedavids.cuba.wizard.gui.components.WizardStep;
 import de.diedavids.cuba.wizard.gui.components.WizardStepAware;
 
 public class WebWizardStep extends WebVBoxLayout implements WizardStep {
+    private String name;
+    private WizardStepAware stepComponent;
+    private TabSheet.Tab tabComponent;
+    private String icon;
+
     public WebWizardStep() {
+
     }
+
+    public WebWizardStep(String name, WizardStepAware stepComponent) {
+        this.name = name;
+        this.stepComponent = stepComponent;
+        this.add((Component) stepComponent);
+    }
+
 
     @Override
     public void onActivate() {
-        getWizardStepAware().onActivate();
+        WizardStepAware wizardStepAware = getWizardStepAware();
+        if (wizardStepAware != null) {
+            wizardStepAware.onActivate();
+        }
     }
 
 
     @Override
     public boolean preClose() {
-        return getWizardStepAware().preClose();
+        WizardStepAware wizardStepAware = getWizardStepAware();
+        if (wizardStepAware != null) {
+            return wizardStepAware.preClose();
+        }
+        else {
+            return false;
+        }
     }
 
 
 
     private WizardStepAware getWizardStepAware() {
-        return (WizardStepAware) ownComponents.get(0);
+        if (ownComponents.size() > 0) {
+            return (WizardStepAware) ownComponents.get(0);
+        }
+        else {
+            return stepComponent;
+        }
     }
 }

--- a/modules/web/src/de/diedavids/cuba/wizard/web/gui/components/WebWizardStep.java
+++ b/modules/web/src/de/diedavids/cuba/wizard/web/gui/components/WebWizardStep.java
@@ -10,10 +10,24 @@ public class WebWizardStep extends WebVBoxLayout implements WizardStep {
     private String name;
     private WizardStepAware stepComponent;
     private TabSheet.Tab tabComponent;
-    private String icon;
 
     public WebWizardStep() {
 
+    }
+
+    @Override
+    public void setIcon(String icon) {
+        if (tabComponent != null) {
+            tabComponent.setIcon(icon);
+        }
+
+    }
+
+    @Override
+    public void setCaption(String caption) {
+        if (tabComponent != null) {
+            tabComponent.setCaption(caption);
+        }
     }
 
     public WebWizardStep(String name, WizardStepAware stepComponent) {
@@ -43,6 +57,10 @@ public class WebWizardStep extends WebVBoxLayout implements WizardStep {
         }
     }
 
+    @Override
+    public void setWrapperComponent(TabSheet.Tab tabComponent) {
+        this.tabComponent = tabComponent;
+    }
 
 
     private WizardStepAware getWizardStepAware() {

--- a/modules/web/src/de/diedavids/cuba/wizard/web/screens/examples/example1/WizardExample1.java
+++ b/modules/web/src/de/diedavids/cuba/wizard/web/screens/examples/example1/WizardExample1.java
@@ -1,7 +1,10 @@
 package de.diedavids.cuba.wizard.web.screens.examples.example1;
 
 import com.haulmont.cuba.gui.components.AbstractWindow;
+import com.haulmont.cuba.gui.xml.layout.ComponentsFactory;
 import de.diedavids.cuba.wizard.gui.components.Wizard;
+import de.diedavids.cuba.wizard.gui.components.WizardStep;
+import de.diedavids.cuba.wizard.gui.components.WizardStepAware;
 
 import javax.inject.Inject;
 
@@ -10,6 +13,10 @@ public class WizardExample1 extends AbstractWindow {
 
     @Inject
     protected Wizard wizard;
+
+
+    @Inject
+    protected ComponentsFactory componentsFactory;
 
     @Override
     public void ready() {
@@ -28,5 +35,14 @@ public class WizardExample1 extends AbstractWindow {
                     event.getPrevStep().getId() + " to " +
                     event.getStep().getId());
         });
+
+
+        WizardStepAware wizardStepAware = (WizardStepAware) openFrame(null, "example-1-step-4-frame");
+
+
+        WizardStep wizardStep = wizard.addStep(3, "Hello", wizardStepAware);
+        wizardStep.setId("Hello");
+        wizardStep.setCaption("Hello 123");
+        wizardStep.setIcon("font-icon:ADN");
     }
 }

--- a/modules/web/src/de/diedavids/cuba/wizard/web/screens/examples/example1/WizardExample1.java
+++ b/modules/web/src/de/diedavids/cuba/wizard/web/screens/examples/example1/WizardExample1.java
@@ -9,13 +9,24 @@ public class WizardExample1 extends AbstractWindow {
 
 
     @Inject
-    protected Wizard wizardPanel;
+    protected Wizard wizard;
 
     @Override
     public void ready() {
-        wizardPanel.addWizardFinishClickListener(event -> {
+        wizard.addWizardFinishClickListener(event -> {
             showNotification("finish clicked");
             close(COMMIT_ACTION_ID);
+        });
+
+        wizard.addWizardCancelClickListener(event -> {
+            showNotification("cancel clicked");
+            close(CLOSE_ACTION_ID);
+        });
+
+        wizard.addWizardStepChangeListener(event -> {
+            showNotification("step changed from " +
+                    event.getPrevStep().getId() + " to " +
+                    event.getStep().getId());
         });
     }
 }

--- a/modules/web/src/de/diedavids/cuba/wizard/web/screens/examples/example1/steps/Example1Step4.java
+++ b/modules/web/src/de/diedavids/cuba/wizard/web/screens/examples/example1/steps/Example1Step4.java
@@ -9,6 +9,6 @@ public class Example1Step4 extends AbstractWizardStep {
 
     @Override
     public void onActivate() {
-        showNotification("on activate step 4");
+        showNotification("on activate step 4", NotificationType.TRAY);
     }
 }

--- a/modules/web/src/de/diedavids/cuba/wizard/web/screens/examples/example1/steps/Example1Step4.java
+++ b/modules/web/src/de/diedavids/cuba/wizard/web/screens/examples/example1/steps/Example1Step4.java
@@ -1,0 +1,14 @@
+package de.diedavids.cuba.wizard.web.screens.examples.example1.steps;
+
+import de.diedavids.cuba.wizard.gui.components.AbstractWizardStep;
+
+public class Example1Step4 extends AbstractWizardStep {
+    public void buttonClick() {
+        showNotification("Hello 4");
+    }
+
+    @Override
+    public void onActivate() {
+        showNotification("on activate step 4");
+    }
+}

--- a/modules/web/src/de/diedavids/cuba/wizard/web/screens/examples/example1/steps/example-1-step-4.xml
+++ b/modules/web/src/de/diedavids/cuba/wizard/web/screens/examples/example1/steps/example-1-step-4.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<window xmlns="http://schemas.haulmont.com/cuba/window.xsd"
+        class="de.diedavids.cuba.wizard.web.screens.examples.example1.steps.Example1Step4"
+        messagesPack="de.diedavids.cuba.wizard.web.screens.examples.example1.steps">
+    <dialogMode height="600"
+                width="800"/>
+    <layout>
+
+        <button id="button"
+                caption="My Frame 4" invoke="buttonClick"/>
+    </layout>
+</window>

--- a/modules/web/src/de/diedavids/cuba/wizard/web/screens/examples/example1/wizard-example-1.xml
+++ b/modules/web/src/de/diedavids/cuba/wizard/web/screens/examples/example1/wizard-example-1.xml
@@ -7,8 +7,8 @@
     <dialogMode height="600"
                 forceDialog="true"
                 width="800"/>
-    <layout expand="wizardPanel">
-        <wizard:wizard id="wizardPanel" width="100%" caption="My Wizard">
+    <layout expand="wizard">
+        <wizard:wizard id="wizard" width="100%" caption="My Wizard">
 
             <wizard:step id="step1"
                          icon="font-icon:ADN"


### PR DESCRIPTION
This PR should add the ability to add wizard steps programmatically. Currently it works. However - there is a display error after the TabSheet.Tab has been added: The icon & name is not used (it is blank).
<img width="1271" alt="bildschirmfoto 2018-07-01 um 21 26 39" src="https://user-images.githubusercontent.com/817400/42138005-aa2ce574-7d76-11e8-970a-c15900a1f5d8.png">
<img width="1271" alt="bildschirmfoto 2018-07-01 um 21 26 42" src="https://user-images.githubusercontent.com/817400/42138004-aa1609da-7d76-11e8-99b8-afc78b80dfa1.png">
<img width="1271" alt="bildschirmfoto 2018-07-01 um 21 26 53" src="https://user-images.githubusercontent.com/817400/42138003-a9fdf5fc-7d76-11e8-9686-cf1c46d35fcc.png">


The desired API should look just like the one from the TabSheet.Tab:

```
WizardStep wizardStep = wizard.addStep(3, "Hello", wizardStepAware);
wizardStep.setId("Hello");
wizardStep.setCaption("Hello 123");
```