### PR TITLE
initial attempt to port to 7.0.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 
 buildscript {
-    ext.cubaVersion = '6.10.7'
+    ext.cubaVersion = '7.0.1'
     repositories {
         mavenCentral()
         maven {
@@ -34,7 +34,6 @@ def webModule = project(":${modulePrefix}-web")
 def servletApi = 'javax.servlet:javax.servlet-api:3.1.0'
 
 
-apply(plugin: 'idea')
 apply(plugin: 'cuba')
 
 cuba {
@@ -103,7 +102,6 @@ def hsql = 'org.hsqldb:hsqldb:2.2.9'
 configure([globalModule, coreModule, guiModule, webModule]) {
     apply(plugin: 'java')
     apply(plugin: 'maven')
-    apply(plugin: 'idea')
     apply(plugin: 'cuba')
 
     dependencies {
@@ -127,6 +125,12 @@ configure([globalModule, coreModule, guiModule, webModule]) {
 }
 
 configure(globalModule) {
+    dependencies {
+        if (!JavaVersion.current().isJava8()) {
+            runtime('javax.xml.bind:jaxb-api:2.3.1')
+            runtime('org.glassfish.jaxb:jaxb-runtime:2.3.1')
+        }
+    }
     entitiesEnhancing {
         main { enabled = true }
     }
@@ -150,7 +154,7 @@ configure(coreModule) {
 
     dependencies {
         compile(globalModule)
-        provided(servletApi)
+        compileOnly(servletApi)
         jdbc(hsql)
         testRuntime(hsql)
 
@@ -208,7 +212,7 @@ configure(webModule) {
     }
 
     dependencies {
-        provided(servletApi)
+        compileOnly(servletApi)
         compile(guiModule)
 
     }
@@ -269,8 +273,5 @@ task restart(dependsOn: ['stop', ":${modulePrefix}-core:deploy", ":${modulePrefi
     }
 }
 
-task wrapper(type: Wrapper) {
-    gradleVersion = '4.3.1'
-}
 
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -2,4 +2,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.3.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.10.3-bin.zip

--- a/modules/core/src/de/diedavids/cuba/wizard/spring.xml
+++ b/modules/core/src/de/diedavids/cuba/wizard/spring.xml
@@ -1,9 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <beans xmlns="http://www.springframework.org/schema/beans"
-       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-       xmlns:context="http://www.springframework.org/schema/context"
-       xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-4.3.xsd
-        http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-4.3.xsd">
+       xmlns:context="http://www.springframework.org/schema/context">
 
     <!-- Annotation-based beans -->
     <context:component-scan base-package="de.diedavids.cuba.wizard"/>

--- a/modules/gui/src/de/diedavids/cuba/wizard/gui/components/Wizard.java
+++ b/modules/gui/src/de/diedavids/cuba/wizard/gui/components/Wizard.java
@@ -2,10 +2,11 @@ package de.diedavids.cuba.wizard.gui.components;
 
 import com.haulmont.cuba.gui.components.Component;
 import com.haulmont.cuba.gui.components.Frame;
+import com.haulmont.cuba.gui.components.OrderedContainer;
 
 import java.util.EventObject;
 
-public interface Wizard extends Component.OrderedContainer,
+public interface Wizard extends OrderedContainer,
                 Component.HasIcon, Component.HasCaption {
     String NAME = "wizard";
 
@@ -45,8 +46,8 @@ public interface Wizard extends Component.OrderedContainer,
     }
 
     @FunctionalInterface
-    interface WizardStepChangeListener {
-        void stepChanged(Wizard.WizardStepChangeEvent event);
+    interface WizardStepChangeListener extends java.util.function.Consumer<Wizard.WizardStepChangeEvent> {
+        void accept(Wizard.WizardStepChangeEvent event);
     }
 
 
@@ -65,8 +66,8 @@ public interface Wizard extends Component.OrderedContainer,
     }
 
     @FunctionalInterface
-    interface WizardCancelClickListener {
-        void cancelClicked(Wizard.WizardCancelClickEvent event);
+    interface WizardCancelClickListener extends java.util.function.Consumer<Wizard.WizardCancelClickEvent> {
+        void accept(Wizard.WizardCancelClickEvent event);
     }
 
 
@@ -87,7 +88,7 @@ public interface Wizard extends Component.OrderedContainer,
     }
 
     @FunctionalInterface
-    interface WizardFinishClickListener {
-        void finishClicked(Wizard.WizardFinishClickEvent event);
+    interface WizardFinishClickListener extends java.util.function.Consumer<Wizard.WizardFinishClickEvent> {
+        void accept(Wizard.WizardFinishClickEvent event);
     }
 }

--- a/modules/gui/src/de/diedavids/cuba/wizard/gui/xml/layout/loaders/WizardLoader.java
+++ b/modules/gui/src/de/diedavids/cuba/wizard/gui/xml/layout/loaders/WizardLoader.java
@@ -22,7 +22,7 @@ public class WizardLoader extends ContainerLoader<Wizard> {
 
     @Override
     public void createComponent() {
-        resultComponent = factory.createComponent(Wizard.class);
+        resultComponent = componentsFactory.createComponent(Wizard.class);
         loadId(resultComponent, element);
 
         List<Element> stepElements = element.elements("step");

--- a/modules/gui/src/de/diedavids/cuba/wizard/gui/xml/layout/loaders/WizardStepLoader.java
+++ b/modules/gui/src/de/diedavids/cuba/wizard/gui/xml/layout/loaders/WizardStepLoader.java
@@ -1,14 +1,18 @@
 package de.diedavids.cuba.wizard.gui.xml.layout.loaders;
 
+import com.haulmont.cuba.core.global.AppBeans;
+import com.haulmont.cuba.gui.xml.layout.ComponentsFactory;
 import com.haulmont.cuba.gui.xml.layout.loaders.AbstractBoxLoader;
 import de.diedavids.cuba.wizard.gui.components.WizardStep;
 import org.dom4j.Element;
 
 public class WizardStepLoader extends AbstractBoxLoader<WizardStep> {
 
+    protected ComponentsFactory componentsFactory = AppBeans.get(ComponentsFactory.NAME);
+
     @Override
     public void createComponent() {
-        resultComponent = (WizardStep) factory.createComponent(WizardStep.NAME);
+        resultComponent = (WizardStep) componentsFactory.createComponent(WizardStep.NAME);
         loadId(resultComponent, element);
         loadCaption(resultComponent, element);
         loadIcon(resultComponent, element);

--- a/modules/web/src/de/diedavids/cuba/wizard/web-app.properties
+++ b/modules/web/src/de/diedavids/cuba/wizard/web-app.properties
@@ -45,3 +45,4 @@ cuba.availableLocales = English|en
 cuba.localeSelectVisible = false
 cuba.restApiUrl = http://localhost:8080/wizard-portal/api
 cuba.webAppUrl = http://localhost:8080/wizard
+cuba.themeConfig=com/haulmont/cuba/havana-theme.properties com/haulmont/cuba/halo-theme.properties com/haulmont/cuba/hover-theme.properties

--- a/modules/web/src/de/diedavids/cuba/wizard/web-dispatcher-spring.xml
+++ b/modules/web/src/de/diedavids/cuba/wizard/web-dispatcher-spring.xml
@@ -1,10 +1,4 @@
 <beans xmlns="http://www.springframework.org/schema/beans"
-       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-       xmlns:context="http://www.springframework.org/schema/context"
-       xsi:schemaLocation="
-           http://www.springframework.org/schema/beans
-           http://www.springframework.org/schema/beans/spring-beans-4.3.xsd
-           http://www.springframework.org/schema/context
-           http://www.springframework.org/schema/context/spring-context-4.3.xsd">
+       xmlns:context="http://www.springframework.org/schema/context">
 
 </beans>

--- a/modules/web/src/de/diedavids/cuba/wizard/web-spring.xml
+++ b/modules/web/src/de/diedavids/cuba/wizard/web-spring.xml
@@ -1,11 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <beans xmlns="http://www.springframework.org/schema/beans"
-       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xmlns:context="http://www.springframework.org/schema/context"
-       xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-4.3.xsd
-        http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-4.3.xsd">
+       xmlns:gui="http://schemas.haulmont.com/cuba/spring/cuba-gui.xsd">
 
     <!-- Annotation-based beans -->
     <context:component-scan base-package="de.diedavids.cuba.wizard"/>
+    <gui:screens base-packages="de.diedavids.cuba.wizard.web"/>
 
 </beans>

--- a/modules/web/src/de/diedavids/cuba/wizard/web/gui/components/WebWizard.java
+++ b/modules/web/src/de/diedavids/cuba/wizard/web/gui/components/WebWizard.java
@@ -6,11 +6,13 @@ import com.haulmont.cuba.gui.components.*;
 import com.haulmont.cuba.gui.components.actions.BaseAction;
 import com.haulmont.cuba.gui.xml.layout.ComponentsFactory;
 import com.haulmont.cuba.web.gui.components.WebComponentsHelper;
-import com.haulmont.cuba.web.toolkit.ui.CubaCssActionsLayout;
+import com.haulmont.cuba.web.widgets.CubaCssActionsLayout;
 import de.diedavids.cuba.wizard.gui.components.Wizard;
 import com.haulmont.cuba.web.gui.components.WebCssLayout;
 import de.diedavids.cuba.wizard.gui.components.WizardStep;
 import de.diedavids.cuba.wizard.gui.components.WizardStepAware;
+
+
 
 import java.util.*;
 
@@ -80,34 +82,34 @@ public class WebWizard extends WebCssLayout implements Wizard {
 
     @Override
     public void addWizardStepChangeListener(WizardStepChangeListener listener) {
-        getEventRouter().addListener(WizardStepChangeListener.class, listener);
+        getEventHub().subscribe(WizardStepChangeEvent.class, listener);
     }
 
     @Override
     public void removeWizardStepChangeListener(WizardStepChangeListener listener) {
-        getEventRouter().removeListener(WizardStepChangeListener.class, listener);
+        getEventHub().unsubscribe(WizardStepChangeEvent.class, listener);
     }
 
 
     @Override
     public void addWizardCancelClickListener(WizardCancelClickListener listener) {
-        getEventRouter().addListener(WizardCancelClickListener.class, listener);
+        getEventHub().subscribe(WizardCancelClickEvent.class, listener);
     }
 
     @Override
     public void removeWizardCancelClickListener(WizardCancelClickListener listener) {
-        getEventRouter().removeListener(WizardCancelClickListener.class, listener);
+        getEventHub().unsubscribe(WizardCancelClickEvent.class, listener);
     }
 
 
     @Override
     public void addWizardFinishClickListener(WizardFinishClickListener listener) {
-        getEventRouter().addListener(WizardFinishClickListener.class, listener);
+        getEventHub().subscribe(WizardFinishClickEvent.class, listener);
     }
 
     @Override
     public void removeWizardFinishClickListener(WizardFinishClickListener listener) {
-        getEventRouter().removeListener(WizardFinishClickListener.class, listener);
+        getEventHub().unsubscribe(WizardFinishClickEvent.class, listener);
     }
 
 
@@ -148,8 +150,8 @@ public class WebWizard extends WebCssLayout implements Wizard {
     }
 
     private void addWizardShortcutActions() {
-        layoutWrapper.addShortcutAction(new Component.ShortcutAction("CTRL-ALT-ARROW_RIGHT", shortcutTriggeredEvent -> nextAction.actionPerform(shortcutTriggeredEvent.getSource())));
-        layoutWrapper.addShortcutAction(new Component.ShortcutAction("CTRL-ALT-ARROW_LEFT", shortcutTriggeredEvent -> prevAction.actionPerform(shortcutTriggeredEvent.getSource())));
+        layoutWrapper.addShortcutAction(new ShortcutAction("CTRL-ALT-ARROW_RIGHT", shortcutTriggeredEvent -> nextAction.actionPerform(shortcutTriggeredEvent.getSource())));
+        layoutWrapper.addShortcutAction(new ShortcutAction("CTRL-ALT-ARROW_LEFT", shortcutTriggeredEvent -> prevAction.actionPerform(shortcutTriggeredEvent.getSource())));
     }
 
     private boolean isStepChangedAllowed() {
@@ -223,8 +225,7 @@ public class WebWizard extends WebCssLayout implements Wizard {
 
     private void handleCancelClick() {
         Wizard.WizardCancelClickEvent event = new Wizard.WizardCancelClickEvent(this);
-        getEventRouter().fireEvent(WizardCancelClickListener.class,
-                Wizard.WizardCancelClickListener::cancelClicked, event);
+        getEventHub().publish(Wizard.WizardCancelClickEvent.class, event);
     }
 
     private Button createPrevBtn() {
@@ -253,8 +254,7 @@ public class WebWizard extends WebCssLayout implements Wizard {
 
 
             Wizard.WizardStepChangeEvent wizardStepChangeEvent = new Wizard.WizardStepChangeEvent(this, prevStep, step);
-            getEventRouter().fireEvent(WizardStepChangeListener.class,
-                    Wizard.WizardStepChangeListener::stepChanged, wizardStepChangeEvent);
+            getEventHub().publish(Wizard.WizardStepChangeEvent.class, wizardStepChangeEvent);
 
         }
     }
@@ -294,8 +294,7 @@ public class WebWizard extends WebCssLayout implements Wizard {
 
     private void handleFinishClick() {
         Wizard.WizardFinishClickEvent finishClickEvent = new Wizard.WizardFinishClickEvent(this);
-        getEventRouter().fireEvent(WizardFinishClickListener.class,
-                Wizard.WizardFinishClickListener::finishClicked, finishClickEvent);
+        getEventHub().publish(Wizard.WizardFinishClickEvent.class, finishClickEvent);
     }
 
     private boolean currentTabIsLastTab() {

--- a/modules/web/src/de/diedavids/cuba/wizard/web/gui/components/WebWizardStep.java
+++ b/modules/web/src/de/diedavids/cuba/wizard/web/gui/components/WebWizardStep.java
@@ -2,11 +2,11 @@ package de.diedavids.cuba.wizard.web.gui.components;
 
 import com.haulmont.cuba.gui.components.Component;
 import com.haulmont.cuba.gui.components.TabSheet;
-import com.haulmont.cuba.web.gui.components.WebVBoxLayout;
+import com.haulmont.cuba.web.gui.components.WebFragment;
 import de.diedavids.cuba.wizard.gui.components.WizardStep;
 import de.diedavids.cuba.wizard.gui.components.WizardStepAware;
 
-public class WebWizardStep extends WebVBoxLayout implements WizardStep {
+public class WebWizardStep extends WebFragment implements WizardStep {
     private String name;
     private WizardStepAware stepComponent;
     private TabSheet.Tab tabComponent;
@@ -66,7 +66,7 @@ public class WebWizardStep extends WebVBoxLayout implements WizardStep {
 
     private WizardStepAware getWizardStepAware() {
         if (ownComponents.size() > 0) {
-            return (WizardStepAware) ownComponents.get(0);
+            return ((WebWizardStep)ownComponents.get(0)).stepComponent;
         }
         else {
             return stepComponent;

--- a/modules/web/web/WEB-INF/web.xml
+++ b/modules/web/web/WEB-INF/web.xml
@@ -3,11 +3,6 @@
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/web-app_3_0.xsd"
          version="3.0">
-    <context-param>
-        <description>Web resources version for correct caching in browser</description>
-        <param-name>webResourcesTs</param-name>
-        <param-value>${webResourcesTs}</param-value>
-    </context-param>
     <!-- Application properties config files -->
     <context-param>
         <param-name>appPropertiesConfig</param-name>

--- a/studio-intellij.xml
+++ b/studio-intellij.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="CubaPluginProjectSettings">
+    <option name="isOneToOneIndex" value="false" />
+    <option name="isNewFkConstraintNaming" value="false" />
+    <option name="isJoinedInheritanceDeleteCascade" value="false" />
+  </component>
+</project>


### PR DESCRIPTION
Ok, I've made an attempt at porting.

However, there are still some issues.  Everything compiles, but an exception is thrown when starting the Example wizard.

There are 2 places I've made changes I'm not 100% sure about:

```
diff --git a/modules/gui/src/de/diedavids/cuba/wizard/gui/xml/layout/loaders/WizardStepLoader.java b/modules/gui/src/de/diedavids/cuba/wizard/gui/xml/layout/loaders/WizardStepLoader.java

-        resultComponent = (WizardStep) factory.createComponent(WizardStep.NAME);
+        resultComponent = (WizardStep) componentsFactory.createComponent(WizardStep.NAME);
```

I'm not sure where `factory` came from before (it wasn't compiling).  There were a few lines where I made this change.

```
diff --git a/modules/web/src/de/diedavids/cuba/wizard/web/gui/components/WebWizardStep.java b/modules/web/src/de/diedavids/cuba/wizard/web/gui/components/WebWizardStep.java

-public class WebWizardStep extends WebVBoxLayout implements WizardStep {
+public class WebWizardStep extends WebFragment implements WizardStep {
     private String name;
     private WizardStepAware stepComponent;
     private TabSheet.Tab tabComponent;
@@ -66,7 +66,7 @@ public class WebWizardStep extends WebVBoxLayout implements WizardStep {

     private WizardStepAware getWizardStepAware() {
         if (ownComponents.size() > 0) {
-            return (WizardStepAware) ownComponents.get(0);
+            return ((WebWizardStep)ownComponents.get(0)).stepComponent;
         }
         else {
             return stepComponent;
```

I'm really not sure about this.  Line 66 is where the exception is being thrown.  It is saying that it can't cast an instance of ....WebFragment to ...WizardStepAware.